### PR TITLE
Use mimalloc as the global allocator + remove unused hashmap of messages

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,25 @@
+# Custom linker + flags for certain targets.
+
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
+# This target is 32-bit, and mimalloc uses CAS operations
+# which are not implemented in hardware on 32-bit architectures,
+# so we need to tell the linker to include the `atomic` library.
+rustflags = ["-C", "link-args=-latomic"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 
+[target.aarch64-unknown-linux-musl]
+# The included linker for this target doesn't seem to work.
+linker = "rust-lld"
+
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
-# # Use the sparse registry protocol for Cargo.
+[target.x86_64-unknown-linux-musl]
+linker = "musl-gcc"
+
+# Use the sparse registry protocol for Cargo.
 [registries.crates-io]
 protocol = "sparse"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -23,7 +23,7 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
 
-      - name: Rust Cache  
+      - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
       - name: Build
@@ -40,12 +40,14 @@ jobs:
         run: cargo clippy
 
       - name: Style
+        # Only run on Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: cargo fmt --all -- --check
-          
+
       - name: Test
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: cargo test      
+        # Don't run on Windows because Unix sockets are not available.
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: cargo test
 
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,6 +102,12 @@ jobs:
             artifact_name: deltio
             asset_name: deltio-${{ needs.tag.outputs.tag }}-linux-aarch64
             install_linker: gcc-aarch64-linux-gnu
+            
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact_name: deltio
+            asset_name: deltio-${{ needs.tag.outputs.tag }}-linux-musl-aarch64
+            install_linker: aarch64-linux-musl-cross
 
           - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-latest
@@ -162,8 +168,15 @@ jobs:
       - name: Install Cross-Platform Linker
         if: ${{ matrix.install_linker }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ matrix.install_linker }}
+          # Special instructions for installing the aarch64 linker for musl
+          if [ "${{ matrix.install_linker }}" = "aarch64-linux-musl-cross" ]; then
+            wget -P ~ https://musl.cc/aarch64-linux-musl-cross.tgz
+            tar -xvf ~/aarch64-linux-musl-cross.tgz -C "${HOME}"
+            echo "${HOME}/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
+          else
+            sudo apt-get update
+            sudo apt-get install -y ${{ matrix.install_linker }}
+          fi
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
 name = "bitflags"
@@ -230,7 +230,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "deltio"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -241,6 +241,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
+ "mimalloc",
  "parking_lot",
  "prost",
  "prost-types",
@@ -607,10 +608,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.3.7"
+name = "libmimalloc-sys"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -642,6 +653,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltio"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Jeff Hansen"]
 description = "A Google Cloud Pub/Sub emulator alternative for local testing and CI"
@@ -24,6 +24,11 @@ log = "0.4.17"
 env_logger = "0.10.0"
 lazy_static = "1.4.0"
 clap = { version = "4.2.7", features = ["derive"] }
+
+# MiMalloc does not currently cross-compile for `i686-unknown-linux-musl` target,
+# so we'll disable MiMalloc for x86 Linux for now.
+[target.'cfg(not(all(target_arch = "x86", target_os = "linux")))'.dependencies]
+mimalloc = { version = "0.1.37", default-features = false }
 
 [dev-dependencies]
 uuid = { version = "1.3.0", features = ["v4", "fast-rng"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,15 @@ use std::sync::Arc;
 use tonic::transport::server::Router;
 use tonic::transport::Server;
 
+#[cfg(not(all(target_arch = "x86", target_os = "linux")))]
+use mimalloc::MiMalloc;
+
+#[cfg(not(all(target_arch = "x86", target_os = "linux")))]
+// Use MiMalloc as the global allocator for supported targets.
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+/// Creates a server builder configured with the Pub/Sub gRPC services.
 pub fn make_server_builder() -> Router {
     let topic_manager = Arc::new(TopicManager::new());
     let subscription_manager = Arc::new(SubscriptionManager::new());

--- a/tests/publisher_topic_test.rs
+++ b/tests/publisher_topic_test.rs
@@ -224,50 +224,47 @@ async fn test_list_topic_subscriptions() {
 
 // Actors: Creating took 244.654333ms, Getting page 2 took 2.243458ms
 // RwLock: Creating took 222.814875ms, Getting page 2 took 2.857791ms
-// #[tokio::test]
-// async fn test_list_bench() {
-//     let mut server = TestHost::start().await.unwrap();
-//     let topic_names = (0..10_000).map(|_| TopicName::new("test", &Uuid::new_v4().to_string()));
-//
-//     let now = std::time::Instant::now();
-//     futures::future::join_all(topic_names.map(|n| {
-//         let name = n.clone();
-//         let mut publisher = server.publisher.clone();
-//         tokio::spawn(async move { create_topic(&mut publisher, &name).await })
-//     }))
-//     .await;
-//     let elapsed = now.elapsed();
-//     println!("Creating took {:?}", elapsed);
-//
-//     // Get the topic that was created.
-//     let list_response = server
-//         .publisher
-//         .list_topics(ListTopicsRequest {
-//             project: "test".to_string(),
-//             page_size: 5_000,
-//             page_token: "".to_string(),
-//         })
-//         .await
-//         .unwrap();
-//
-//     let list_response = list_response.get_ref();
-//     assert_eq!(list_response.topics.len(), 5_000);
-//
-//     let now = std::time::Instant::now();
-//     // Get the next page.
-//     let list_response = server
-//         .publisher
-//         .list_topics(ListTopicsRequest {
-//             project: "test".to_string(),
-//             page_size: 5_000,
-//             page_token: list_response.next_page_token.clone(),
-//         })
-//         .await
-//         .unwrap();
-//     let elapsed = now.elapsed();
-//     println!("Getting page 2 took {:?}", elapsed);
-//     let list_response = list_response.get_ref();
-//     assert_eq!(list_response.topics.len(), 5_000);
-//
-//     server.dispose().await;
-// }
+#[tokio::test]
+async fn test_list_bench() {
+    let mut server = TestHost::start().await.unwrap();
+    let topic_names = (0..10_000).map(|_| TopicName::new("test", &Uuid::new_v4().to_string()));
+
+    let now = std::time::Instant::now();
+    futures::future::join_all(topic_names.map(|n| {
+        let mut publisher = server.publisher.clone();
+        tokio::spawn(async move { publisher.create_topic(map_to_topic_resource(&n)).await })
+    }))
+    .await;
+    let elapsed = now.elapsed();
+    println!("Creating took {:?}", elapsed);
+
+    // Get the topic that was created.
+    let list_response = server
+        .publisher
+        .list_topics(ListTopicsRequest {
+            project: "projects/test".to_string(),
+            page_size: 1_000,
+            page_token: "".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let list_response = list_response.get_ref();
+    assert_eq!(list_response.topics.len(), 1_000);
+
+    let now = std::time::Instant::now();
+    // Get the next page.
+    server
+        .publisher
+        .list_topics(ListTopicsRequest {
+            project: "projects/test".to_string(),
+            page_size: 1_000,
+            page_token: list_response.next_page_token.clone(),
+        })
+        .await
+        .unwrap();
+    let elapsed = now.elapsed();
+    println!("Getting page 2 took {:?}", elapsed);
+
+    server.dispose().await;
+}

--- a/tests/publisher_topic_test.rs
+++ b/tests/publisher_topic_test.rs
@@ -222,49 +222,47 @@ async fn test_list_topic_subscriptions() {
     assert_eq!(page.next_page_token, String::default());
 }
 
-// Actors: Creating took 244.654333ms, Getting page 2 took 2.243458ms
-// RwLock: Creating took 222.814875ms, Getting page 2 took 2.857791ms
-#[tokio::test]
-async fn test_list_bench() {
-    let mut server = TestHost::start().await.unwrap();
-    let topic_names = (0..10_000).map(|_| TopicName::new("test", &Uuid::new_v4().to_string()));
-
-    let now = std::time::Instant::now();
-    futures::future::join_all(topic_names.map(|n| {
-        let mut publisher = server.publisher.clone();
-        tokio::spawn(async move { publisher.create_topic(map_to_topic_resource(&n)).await })
-    }))
-    .await;
-    let elapsed = now.elapsed();
-    println!("Creating took {:?}", elapsed);
-
-    // Get the topic that was created.
-    let list_response = server
-        .publisher
-        .list_topics(ListTopicsRequest {
-            project: "projects/test".to_string(),
-            page_size: 1_000,
-            page_token: "".to_string(),
-        })
-        .await
-        .unwrap();
-
-    let list_response = list_response.get_ref();
-    assert_eq!(list_response.topics.len(), 1_000);
-
-    let now = std::time::Instant::now();
-    // Get the next page.
-    server
-        .publisher
-        .list_topics(ListTopicsRequest {
-            project: "projects/test".to_string(),
-            page_size: 1_000,
-            page_token: list_response.next_page_token.clone(),
-        })
-        .await
-        .unwrap();
-    let elapsed = now.elapsed();
-    println!("Getting page 2 took {:?}", elapsed);
-
-    server.dispose().await;
-}
+// #[tokio::test]
+// async fn test_list_bench() {
+//     let mut server = TestHost::start().await.unwrap();
+//     let topic_names = (0..10_000).map(|_| TopicName::new("test", &Uuid::new_v4().to_string()));
+//
+//     let now = std::time::Instant::now();
+//     futures::future::join_all(topic_names.map(|n| {
+//         let mut publisher = server.publisher.clone();
+//         tokio::spawn(async move { publisher.create_topic(map_to_topic_resource(&n)).await })
+//     }))
+//     .await;
+//     let elapsed = now.elapsed();
+//     println!("Creating took {:?}", elapsed);
+//
+//     // Get the topic that was created.
+//     let list_response = server
+//         .publisher
+//         .list_topics(ListTopicsRequest {
+//             project: "projects/test".to_string(),
+//             page_size: 1_000,
+//             page_token: "".to_string(),
+//         })
+//         .await
+//         .unwrap();
+//
+//     let list_response = list_response.get_ref();
+//     assert_eq!(list_response.topics.len(), 1_000);
+//
+//     let now = std::time::Instant::now();
+//     // Get the next page.
+//     server
+//         .publisher
+//         .list_topics(ListTopicsRequest {
+//             project: "projects/test".to_string(),
+//             page_size: 1_000,
+//             page_token: list_response.next_page_token.clone(),
+//         })
+//         .await
+//         .unwrap();
+//     let elapsed = now.elapsed();
+//     println!("Getting page 2 took {:?}", elapsed);
+//
+//     server.dispose().await;
+// }


### PR DESCRIPTION
MiMalloc should be a better option on musl-based Linux as well as on macOS for multi-threaded apps.

Also added support for `aarch64-unknown-linux-musl` and made the Docker image use `scratch` + the `musl` build.