### PR TITLE
Fix Docker build for musl + update packages

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,14 +11,13 @@ rustflags = ["-C", "link-args=-latomic"]
 linker = "aarch64-linux-gnu-gcc"
 
 [target.aarch64-unknown-linux-musl]
-# The included linker for this target doesn't seem to work.
 linker = "rust-lld"
 
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
 [target.x86_64-unknown-linux-musl]
-linker = "musl-gcc"
+linker = "rust-lld"
 
 # Use the sparse registry protocol for Cargo.
 [registries.crates-io]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -924,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustix"
@@ -1249,9 +1249,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "deltio"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
+ "once_cell",
  "strsim",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ parking_lot = "0.12.1"
 log = "0.4.17"
 env_logger = "0.10.0"
 lazy_static = "1.4.0"
-clap = { version = "4.2.7", features = ["derive"] }
+clap = { version = "4.2.7", features = ["derive", "cargo"] }
 
 # MiMalloc does not currently cross-compile for `i686-unknown-linux-musl` target,
 # so we'll disable MiMalloc for x86 Linux for now.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltio"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Jeff Hansen"]
 description = "A Google Cloud Pub/Sub emulator alternative for local testing and CI"

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,11 @@ async fn main_core(args: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let server = make_server_builder();
 
     // Start listening (TCP).
-    log::info!("Deltio starting, listening on {}", &args.bind);
+    log::info!(
+        "Deltio v{} starting, listening on {}",
+        clap::crate_version!(),
+        &args.bind
+    );
     server.serve_with_shutdown(args.bind, signal).await?;
 
     log::info!("Deltio stopped");


### PR DESCRIPTION
The Docker build script was not building for musl linux if the build and target platforms were the same. That meant that the `linux/amd64` build wouldn't be compiled for musl, and when running that on the scratch image on a stripped-down OS like on Kubernetes, the `libc` libraries would not load.

This was fixed by always building for musl.

Additionally, the Deltio version number is now included in the start log message. Packages were also updated.
