### PR TITLE
Add basic support for Push Subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -85,7 +85,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -188,9 +188,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
 dependencies = [
  "anstream",
  "anstyle",
@@ -213,14 +213,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -370,9 +370,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -433,7 +433,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -747,9 +747,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -769,9 +769,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -779,12 +779,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "matchit"
@@ -815,14 +812,13 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -861,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
@@ -888,7 +884,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -921,22 +917,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -965,7 +961,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1004,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -1067,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1106,15 +1102,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -1124,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1178,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -1242,22 +1229,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1336,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1353,15 +1340,16 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1390,7 +1378,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1410,9 +1398,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1445,7 +1433,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1577,7 +1565,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1618,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1686,7 +1674,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -1720,7 +1708,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1800,35 +1788,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.5",
+ "hyper 0.14.26",
  "itoa",
  "matchit",
  "memchr",
@@ -143,7 +143,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http",
- "http-body",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
@@ -161,6 +161,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytes"
@@ -230,8 +236,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "deltio"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -240,6 +262,8 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
+ "http-body-util",
+ "hyper 1.0.0-rc.3",
  "lazy_static",
  "log",
  "mimalloc",
@@ -247,6 +271,9 @@ dependencies = [
  "prost",
  "prost-types",
  "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -261,6 +288,15 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -316,6 +352,30 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -486,6 +546,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92445bc9cc14bfa0a3ce56817dc3b5bcc227a168781a356b702410789cec0d10"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body 1.0.0-rc.2",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,7 +598,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "http-body",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -528,15 +611,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 1.0.0-rc.2",
+ "http-body-util",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.26",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.26",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -570,6 +698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +729,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -689,6 +832,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +864,50 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "openssl"
+version = "0.10.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -774,6 +979,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -929,6 +1140,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body 0.4.5",
+ "hyper 0.14.26",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,16 +1197,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "security-framework"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1071,6 +1394,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1446,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.16",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1149,8 +1497,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.5",
+ "hyper 0.14.26",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -1248,10 +1596,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1270,6 +1644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1664,82 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+
+[[package]]
+name = "web-sys"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"
@@ -1326,6 +1782,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1458,3 +1929,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltio"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Jeff Hansen"]
 description = "A Google Cloud Pub/Sub emulator alternative for local testing and CI"
@@ -23,6 +23,9 @@ parking_lot = "0.12.1"
 log = "0.4.17"
 env_logger = "0.10.0"
 lazy_static = "1.4.0"
+reqwest = "0.11.18"
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.96"
 clap = { version = "4.2.7", features = ["derive", "cargo"] }
 
 # MiMalloc does not currently cross-compile for `i686-unknown-linux-musl` target,
@@ -34,6 +37,8 @@ mimalloc = { version = "0.1.37", default-features = false }
 uuid = { version = "1.3.0", features = ["v4", "fast-rng"] }
 tokio = { version = "1.28.0", features = ["full", "test-util"] }
 rand = "0.8.5"
+hyper = { version = "1.0.0-rc.3", features = ["server", "http-body-util", "http1"] }
+http-body-util = "0.1.0-rc.2"
 
 [build-dependencies]
 tonic-build = { version = "0.9.1" }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ As of this time, Deltio has **very limited functionality**, much less than the o
 * Streaming-pull messages
   * Including handling stream requests for acks and deadline modifications
   * Does **NOT** support flow control properties
+* Push subscriptions
+  * No flow control
 * Message expiration
 * Deleting subscriptions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 mod collections;
 pub mod paging;
 pub mod pubsub_proto;
+pub mod push;
 pub mod subscriptions;
 pub mod topics;
 mod tracing;
@@ -13,9 +14,12 @@ use crate::subscriptions::subscription_manager::SubscriptionManager;
 use crate::topics::topic_manager::TopicManager;
 use api::publisher::PublisherService;
 use std::sync::Arc;
+use std::time::Duration;
 use tonic::transport::server::Router;
 use tonic::transport::Server;
 
+use crate::push::push_loop::PushLoop;
+use crate::push::PushSubscriptionsRegistry;
 #[cfg(not(all(target_arch = "x86", target_os = "linux")))]
 use mimalloc::MiMalloc;
 
@@ -24,15 +28,58 @@ use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-/// Creates a server builder configured with the Pub/Sub gRPC services.
-pub fn make_server_builder() -> Router {
-    let topic_manager = Arc::new(TopicManager::new());
-    let subscription_manager = Arc::new(SubscriptionManager::new());
+/// Represents the application and it's components.
+pub struct Deltio {
+    /// The push subscriptions registry.
+    /// Used by subscriptions to register and unregister themselves,
+    /// as well as the push loop in order to retrieve registered subscriptions
+    /// and their push config.
+    push_subscriptions_registry: PushSubscriptionsRegistry,
 
-    let publisher_service = PublisherService::new(topic_manager.clone());
-    let subscriber_service = SubscriberService::new(topic_manager, subscription_manager);
+    /// The topic manager, which manages Pub/Sub topics.
+    topic_manager: Arc<TopicManager>,
 
-    Server::builder()
-        .add_service(PublisherServer::new(publisher_service))
-        .add_service(SubscriberServer::new(subscriber_service))
+    /// The subscription manager, which manages Pub/Sub subscriptions.
+    subscription_manager: Arc<SubscriptionManager>,
+}
+
+impl Deltio {
+    /// Creates a new Deltio components wrapper.
+    pub fn new() -> Self {
+        let push_subscriptions_registry = PushSubscriptionsRegistry::new();
+        Self {
+            push_subscriptions_registry: push_subscriptions_registry.clone(),
+            topic_manager: Arc::new(TopicManager::new()),
+            subscription_manager: Arc::new(SubscriptionManager::new(push_subscriptions_registry)),
+        }
+    }
+
+    /// Creates a Tonic gRPC server builder with the
+    /// Pub/Sub gRPC services registered.
+    pub fn server_builder(&self) -> Router {
+        let publisher_service = PublisherService::new(Arc::clone(&self.topic_manager));
+        let subscriber_service = SubscriberService::new(
+            Arc::clone(&self.topic_manager),
+            Arc::clone(&self.subscription_manager),
+        );
+
+        Server::builder()
+            .add_service(PublisherServer::new(publisher_service))
+            .add_service(SubscriberServer::new(subscriber_service))
+    }
+
+    /// Creates the push loop.
+    pub fn push_loop(&self, interval: Duration) -> PushLoop {
+        PushLoop::new(
+            interval,
+            Arc::clone(&self.subscription_manager),
+            self.push_subscriptions_registry.clone(),
+        )
+    }
+}
+
+impl Default for Deltio {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -1,0 +1,66 @@
+pub mod push_loop;
+
+use crate::subscriptions::{PushConfig, SubscriptionName};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Used for registering, unregistering and querying for push subscriptions.
+///
+/// Since push subscriptions are done at an interval rather than in real-time,
+/// we need the ability to retrieve the registered subscriptions in order to pull
+/// messages from them. `Subscription`s have a reference to the registry and
+/// may register or unregister themselves based on config changes.
+#[derive(Clone)]
+pub struct PushSubscriptionsRegistry {
+    /// The registry state.
+    ///
+    /// We use an `RwLock` because the values are only modified
+    /// when push subscriptions are created or their push config is updated.
+    state: Arc<RwLock<PushSubscriptionsRegistryState>>,
+}
+
+/// Maintains a map of subscriptions that are configured for HTTP push
+/// as well as their push configuration.
+struct PushSubscriptionsRegistryState {
+    /// A map of subscriptions that have HTTP push enabled.
+    pub push_subscriptions: HashMap<SubscriptionName, PushConfig>,
+}
+
+impl PushSubscriptionsRegistry {
+    /// Creates a new `PushSubscriptionsRegistry`.
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(PushSubscriptionsRegistryState {
+                push_subscriptions: HashMap::default(),
+            })),
+        }
+    }
+
+    /// Sets the push config for the given subscription ID.
+    /// If `config` is `None`, removes the current entry.
+    pub fn set(&self, name: SubscriptionName, config: Option<PushConfig>) {
+        let mut state = self.state.write();
+        if let Some(config) = config {
+            state.push_subscriptions.entry(name).or_insert(config);
+        } else {
+            let _ = state.push_subscriptions.remove(&name);
+        }
+    }
+
+    /// Gets the entries in the registry.
+    pub fn entries(&self) -> Vec<(SubscriptionName, PushConfig)> {
+        let state = self.state.read();
+        state
+            .push_subscriptions
+            .iter()
+            .map(|(id, pc)| (id.clone(), pc.clone()))
+            .collect::<Vec<_>>()
+    }
+}
+
+impl Default for PushSubscriptionsRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/push/push_loop.rs
+++ b/src/push/push_loop.rs
@@ -1,0 +1,231 @@
+use crate::push::PushSubscriptionsRegistry;
+use crate::subscriptions::subscription_manager::SubscriptionManager;
+use crate::subscriptions::{
+    DeadlineModification, GetSubscriptionError, PullMessagesError, PulledMessage, PushConfig,
+    Subscription,
+};
+use std::collections::HashMap;
+
+use crate::topics::TopicMessage;
+use base64::Engine;
+use futures::FutureExt;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Contains everything needed to run the push loop.
+pub struct PushLoop {
+    interval: Duration,
+    subscription_manager: Arc<SubscriptionManager>,
+    push_registry: PushSubscriptionsRegistry,
+}
+
+impl PushLoop {
+    /// Creates a new push loop.
+    pub fn new(
+        interval: Duration,
+        subscription_manager: Arc<SubscriptionManager>,
+        push_registry: PushSubscriptionsRegistry,
+    ) -> Self {
+        Self {
+            interval,
+            subscription_manager,
+            push_registry,
+        }
+    }
+
+    /// Consumes the `PushLoop` by running it.
+    pub async fn run(self) {
+        run(self.interval, self.subscription_manager, self.push_registry).await
+    }
+}
+
+/// Runs the global push subscription loop.
+pub async fn run(
+    interval: Duration,
+    subscription_manager: Arc<SubscriptionManager>,
+    push_registry: PushSubscriptionsRegistry,
+) {
+    // This is a pretty crude implementation with little to no resilience in
+    // terms of dealing with push endpoint issues. Additionally, there will be no
+    // mercy towards slow endpoints.
+    // In the future, an alternative implementation could be running a push
+    // loop per subscription and only send a few messages at a time.
+    log::trace!("Starting push loop (interval = {:?})", &interval);
+
+    // The HTTP client to use.
+    let client = reqwest::Client::new();
+
+    loop {
+        let entries = push_registry.entries();
+        if !entries.is_empty() {
+            for (name, push_config) in entries {
+                let subscription = match subscription_manager.get_subscription(&name) {
+                    Ok(s) => s,
+                    // The subscription was likely deleted and haven't been cleaned up
+                    // yet. We can safely ignore it.
+                    Err(GetSubscriptionError::Closed | GetSubscriptionError::DoesNotExist) => {
+                        continue
+                    }
+                };
+
+                tokio::spawn(pull_and_dispatch_messages(
+                    subscription,
+                    push_config,
+                    client.clone(),
+                ));
+            }
+        }
+
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Pushes and dispatches messages for the given subscription and push config.
+async fn pull_and_dispatch_messages(
+    subscription: Arc<Subscription>,
+    push_config: PushConfig,
+    client: reqwest::Client,
+) {
+    // Pull the subscription.
+    let deleted_signal = subscription.deleted();
+    let fut = async move {
+        let page = match subscription.pull_messages(1_000).await {
+            Ok(page) => page,
+            Err(PullMessagesError::Closed) => return,
+        };
+
+        let mut join_set = tokio::task::JoinSet::new();
+        for pulled_message in page {
+            // We'll share the dispatch future so we can ensure it gets polled to completion
+            // inside the join set, but we are also able to use it
+            // on the outside to wait for either the dispatch to complete, or a short sleep
+            // whichever is faster. The idea is that if the dispatch is faster than the sleep,
+            // then we don't need to wait for that entire duration.
+            let dispatch_fut = dispatch_message(
+                Arc::clone(&subscription),
+                pulled_message,
+                push_config.clone(),
+                client.clone(),
+            )
+            .shared();
+            join_set.spawn(dispatch_fut.clone());
+
+            // Wait a bit to increase the likelihood of delivering
+            // the messages in order.
+            tokio::select!(
+                _ = dispatch_fut => {},
+                _ = tokio::time::sleep(Duration::from_millis(5)) => {}
+            )
+        }
+
+        // Join all the tasks.
+        while (join_set.join_next().await).is_some() {}
+    };
+
+    // Wait until the push is done or until the subscription is deleted.
+    tokio::select! {
+        _ = deleted_signal => {},
+        _ = fut => {}
+    }
+}
+
+/// Dispatches the message to the push endpoint and ACK/NACks it accordingly.
+async fn dispatch_message(
+    subscription: Arc<Subscription>,
+    pulled_message: PulledMessage,
+    push_config: PushConfig,
+    client: reqwest::Client,
+) {
+    let message = pulled_message.message();
+    log::trace!(
+        "{}: dispatching push message to {}",
+        &subscription.name,
+        &push_config.endpoint
+    );
+    let result = client
+        .request(reqwest::Method::POST, &push_config.endpoint)
+        .header("Content-Type", "application/json;charset=utf8")
+        .body(encode_message_payload(&subscription, message))
+        .send()
+        .await;
+    let success = match result {
+        Ok(response) => {
+            let status: u16 = response.status().into();
+
+            if !matches!(status, 102 | 200 | 201 | 202 | 204) {
+                log::error!(
+                    "{}: failed pushing to endpoint '{}': the endpoint returned a non-successful status code {}",
+                    &subscription.name,
+                    &push_config.endpoint,
+                    status
+                );
+                false
+            } else {
+                true
+            }
+        }
+        Err(send_error) => {
+            log::error!(
+                "{}: failed pushing to endpoint '{}': {}",
+                &subscription.name,
+                &push_config.endpoint,
+                send_error
+            );
+            false
+        }
+    };
+
+    if !success {
+        let _ = subscription
+            .modify_ack_deadlines(vec![DeadlineModification::nack(pulled_message.ack_id())])
+            .await;
+    } else {
+        let _ = subscription
+            .acknowledge_messages(vec![pulled_message.ack_id()])
+            .await;
+    }
+}
+
+/// The payload in JSON form being sent in the request.
+#[derive(Serialize, Deserialize)]
+pub struct PushPayload {
+    pub message: PushPayloadMessage,
+    pub subscription: String,
+}
+
+/// The message in JSON form.
+///
+/// The `_dupe` fields are to support both casings, as per
+/// https://cloud.google.com/pubsub/docs/push#receive_push
+#[derive(Serialize, Deserialize)]
+pub struct PushPayloadMessage {
+    pub attributes: HashMap<String, String>,
+    pub data: String,
+    pub message_id: String,
+    pub publish_time: String,
+    #[serde(rename = "messageId")]
+    pub message_id_dupe: String,
+    #[serde(rename = "publishTime")]
+    pub publish_time_dupe: String,
+}
+
+/// Encodes the message payload to JSON.
+fn encode_message_payload(subscription: &Arc<Subscription>, message: &Arc<TopicMessage>) -> String {
+    // TODO: Format publish time correctly. chrono/time crate?
+    let encoded_data = base64::engine::general_purpose::STANDARD.encode(message.data.clone());
+
+    let payload = PushPayload {
+        subscription: subscription.name.to_string(),
+        message: PushPayloadMessage {
+            data: encoded_data,
+            message_id: message.id.to_string(),
+            message_id_dupe: message.id.to_string(),
+            attributes: HashMap::default(),
+            publish_time: "2000-01-01T12:00:00Z".to_string(),
+            publish_time_dupe: "2000-01-01T12:00:00Z".to_string(),
+        },
+    };
+
+    serde_json::to_string(&payload).unwrap()
+}

--- a/src/subscriptions/outstanding.rs
+++ b/src/subscriptions/outstanding.rs
@@ -10,9 +10,6 @@ pub(crate) struct OutstandingMessageTracker {
     messages: HashMap<AckId, PulledMessage>,
 
     /// A sorted set of expirations. Used for scheduling NACKs.
-    ///
-    /// Since we want a min-heap (popping the lowest value first), we
-    /// need to wrap the items in `Reverse`.
     expirations: BTreeSet<(AckDeadline, AckId)>,
 
     /// Notify when a new, earlier deadline has been inserted.

--- a/src/subscriptions/subscription_name.rs
+++ b/src/subscriptions/subscription_name.rs
@@ -89,6 +89,16 @@ mod tests {
     }
 
     #[test]
+    fn lol() {
+        println!("{}", std::mem::size_of::<SubscriptionName>());
+        println!("{}", std::mem::size_of::<u32>());
+        println!(
+            "{}",
+            std::mem::size_of::<std::sync::Arc<SubscriptionName>>()
+        );
+    }
+
+    #[test]
     fn parse_invalid() {
         assert_eq!(
             SubscriptionName::try_parse("projects/lets-go/subscriptions"),

--- a/tests/publisher_topic_test.rs
+++ b/tests/publisher_topic_test.rs
@@ -154,6 +154,8 @@ async fn test_delete() {
         .await
         .unwrap_err();
     assert_eq!(status.code(), Code::NotFound);
+
+    server.dispose().await;
 }
 
 #[tokio::test]
@@ -220,6 +222,8 @@ async fn test_list_topic_subscriptions() {
 
     assert_eq!(page.subscriptions.len(), 0);
     assert_eq!(page.next_page_token, String::default());
+
+    server.dispose().await;
 }
 
 // #[tokio::test]

--- a/tests/push_server/mod.rs
+++ b/tests/push_server/mod.rs
@@ -1,0 +1,155 @@
+use base64::Engine;
+use std::convert::Infallible;
+use std::error::Error;
+use std::ops::Deref;
+
+use deltio::push::push_loop::PushPayload;
+use http_body_util::{BodyExt, Empty};
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+/// A test server for receiving push messages.
+pub struct TestPushServer {
+    /// The URL to register for push.
+    url: String,
+    /// The join handle for joining the server future.
+    join_handle: JoinHandle<()>,
+    /// Receiver for push payloads.
+    recv: tokio::sync::mpsc::UnboundedReceiver<PushHandle>,
+}
+
+/// What to do with a pushed message.
+#[derive(Debug)]
+pub enum PushResult {
+    Succeed,
+    Fail,
+}
+
+/// A handle for controlling what to do with a pushed message.
+pub struct PushHandle {
+    /// The pushed payload.
+    payload: PushPayload,
+    /// Whether to succeed or fail the handler.
+    responder: tokio::sync::oneshot::Sender<PushResult>,
+}
+
+impl TestPushServer {
+    /// Starts a test push server.
+    pub async fn start() -> Result<TestPushServer, Box<dyn Error>> {
+        // Bind to a random available port.
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?.to_string();
+        let url = format!("http://{addr}");
+        let (sender, recv) = tokio::sync::mpsc::unbounded_channel::<PushHandle>();
+
+        let join_handle = tokio::spawn({
+            async move {
+                loop {
+                    let (stream, _) = match listener.accept().await {
+                        Ok(r) => r,
+                        Err(err) => {
+                            println!("Failed to accept socket: {:?}", err);
+                            continue;
+                        }
+                    };
+
+                    let sender = sender.clone();
+                    let handle_request = move |req: Request<hyper::body::Incoming>| {
+                        let sender = sender.clone();
+                        async move {
+                            let body = req.collect().await.unwrap().aggregate();
+                            let payload: PushPayload =
+                                serde_json::from_reader(bytes::Buf::reader(body)).unwrap();
+                            let (responder, recv) = tokio::sync::oneshot::channel();
+                            let _ = sender.send(PushHandle::new(payload, responder));
+                            let result = recv.await.expect("no response");
+
+                            let mut resp = Response::new(Empty::<Bytes>::default());
+                            *resp.status_mut() = match result {
+                                PushResult::Succeed => StatusCode::OK,
+                                PushResult::Fail => StatusCode::BAD_REQUEST,
+                            };
+                            Ok::<_, Infallible>(resp)
+                        }
+                    };
+
+                    // Spawn a tokio task to serve multiple connections concurrently
+                    tokio::task::spawn(async move {
+                        if let Err(err) = http1::Builder::new()
+                            .serve_connection(stream, service_fn(handle_request))
+                            .await
+                        {
+                            println!("Error serving connection: {:?}", err);
+                        }
+                    });
+                }
+            }
+        });
+
+        let server = TestPushServer {
+            url,
+            join_handle,
+            recv,
+        };
+        Ok(server)
+    }
+
+    /// Returns the URL for the server.
+    pub fn url(&self) -> String {
+        self.url.clone()
+    }
+
+    /// Waits for the next push payload.
+    pub async fn next(&mut self) -> Option<PushHandle> {
+        self.recv.recv().await
+    }
+
+    /// Dispose the server.
+    pub async fn dispose(self) {
+        // Abort the running task.
+        self.join_handle.abort();
+        let _ = self.join_handle.await;
+    }
+}
+
+impl PushHandle {
+    /// Creates a new push handle.
+    fn new(payload: PushPayload, responder: tokio::sync::oneshot::Sender<PushResult>) -> Self {
+        Self { payload, responder }
+    }
+
+    /// Succeeds the pushed message.
+    pub fn succeed(self) {
+        self.responder
+            .send(PushResult::Succeed)
+            .expect("failed to send response");
+    }
+
+    /// Fails the pushed message.
+    pub fn fail(self) {
+        self.responder
+            .send(PushResult::Fail)
+            .expect("failed to send response");
+    }
+}
+
+impl Deref for PushHandle {
+    type Target = PushPayload;
+
+    fn deref(&self) -> &Self::Target {
+        &self.payload
+    }
+}
+
+/// Decodes the data field from the push message.
+pub fn decode_data(push_payload: &PushPayload) -> String {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(&push_payload.message.data)
+        .ok()
+        .unwrap();
+    String::from_utf8(decoded).unwrap()
+}

--- a/tests/push_test.rs
+++ b/tests/push_test.rs
@@ -1,0 +1,138 @@
+use crate::push_server::{decode_data, TestPushServer};
+use deltio::pubsub_proto::Subscription;
+use deltio::pubsub_proto::{PullRequest, PushConfig};
+use deltio::subscriptions::SubscriptionName;
+use deltio::topics::TopicName;
+use std::time::Duration;
+use test_helpers::*;
+
+pub mod push_server;
+pub mod test_helpers;
+
+#[tokio::test]
+async fn test_push_subscription() {
+    let mut server = TestHost::start().await.unwrap();
+    let mut push_server = TestPushServer::start().await.unwrap();
+
+    // Create a topic to subscribe to.
+    let topic_name = TopicName::new("test", "topic");
+    server.create_topic_with_name(&topic_name).await;
+
+    // Create a subscription configured for push.
+    let subscription_name = SubscriptionName::new("test", "subscription");
+    server
+        .subscriber
+        .create_subscription(Subscription {
+            push_config: Some(PushConfig {
+                attributes: Default::default(),
+                authentication_method: None,
+                push_endpoint: push_server.url(),
+            }),
+            ..map_to_subscription_resource(&subscription_name, &topic_name)
+        })
+        .await
+        .unwrap();
+
+    // Publish some messages.
+    server
+        .publish_text_messages(&topic_name, vec!["Hello".into(), "World".into()])
+        .await;
+
+    // Wait for the push server to receive them.
+    // Advance time to make that happen a bit faster.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::time::resume();
+    let payload1 = push_server.next().await.unwrap();
+    assert_eq!(payload1.subscription, subscription_name.to_string());
+    assert_eq!(
+        payload1.message.message_id,
+        payload1.message.message_id_dupe
+    );
+    assert_eq!(decode_data(&payload1), "Hello");
+    payload1.succeed();
+
+    let payload2 = push_server.next().await.unwrap();
+    assert_eq!(decode_data(&payload2), "World");
+    payload2.succeed();
+
+    // Advance enough time to ensure that no redelivery will occur.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(120)).await;
+    tokio::time::resume();
+
+    // Pull using RPC to verify.
+    // Need to use `return_immediately` since we expect no messages.
+    #[allow(deprecated)]
+    let pull_response = server
+        .subscriber
+        .pull(PullRequest {
+            subscription: subscription_name.to_string(),
+            max_messages: 10,
+            return_immediately: true,
+        })
+        .await
+        .unwrap();
+    let pull_response = pull_response.get_ref();
+    assert!(
+        pull_response.received_messages.is_empty(),
+        "there should be no more messages as they were all acked"
+    );
+}
+
+#[tokio::test]
+async fn test_push_subscription_redelivery() {
+    let mut server = TestHost::start().await.unwrap();
+    let mut push_server = TestPushServer::start().await.unwrap();
+
+    // Create a topic to subscribe to.
+    let topic_name = TopicName::new("test", "topic");
+    server.create_topic_with_name(&topic_name).await;
+
+    // Create a subscription configured for push.
+    let subscription_name = SubscriptionName::new("test", "subscription");
+    server
+        .subscriber
+        .create_subscription(Subscription {
+            push_config: Some(PushConfig {
+                attributes: Default::default(),
+                authentication_method: None,
+                push_endpoint: push_server.url(),
+            }),
+            ..map_to_subscription_resource(&subscription_name, &topic_name)
+        })
+        .await
+        .unwrap();
+
+    // Publish some messages.
+    server
+        .publish_text_messages(&topic_name, vec!["Hello".into(), "World".into()])
+        .await;
+
+    // Wait for the push server to receive them.
+    // Advance time to make that happen a bit faster.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::time::resume();
+    let payload1 = push_server.next().await.unwrap();
+    assert_eq!(payload1.subscription, subscription_name.to_string());
+    assert_eq!(
+        payload1.message.message_id,
+        payload1.message.message_id_dupe
+    );
+    assert_eq!(decode_data(&payload1), "Hello");
+    payload1.succeed();
+
+    let payload2 = push_server.next().await.unwrap();
+    assert_eq!(decode_data(&payload2), "World");
+    payload2.fail();
+
+    // Advance enough time to ensure that the message we NACK'ed is redelivered.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::time::resume();
+
+    let payload2 = push_server.next().await.unwrap();
+    assert_eq!(decode_data(&payload2), "World");
+    payload2.succeed();
+}

--- a/tests/subscription_test.rs
+++ b/tests/subscription_test.rs
@@ -1,15 +1,17 @@
 use bytes::Bytes;
+use deltio::push::PushSubscriptionsRegistry;
 use deltio::subscriptions::subscription_manager::SubscriptionManager;
 use deltio::subscriptions::*;
 use deltio::topics::topic_manager::TopicManager;
 use deltio::topics::*;
 use std::sync::Arc;
+use std::time::Duration;
 use uuid::Uuid;
 
 #[tokio::test]
 async fn pulling_messages() {
     let topic_manager = TopicManager::new();
-    let subscription_manager = SubscriptionManager::new();
+    let subscription_manager = SubscriptionManager::new(Default::default());
     let (topic, subscription) =
         new_topic_and_subscription(&topic_manager, &subscription_manager).await;
 
@@ -62,7 +64,7 @@ async fn pulling_messages() {
 #[tokio::test]
 async fn nack_messages() {
     let topic_manager = TopicManager::new();
-    let subscription_manager = SubscriptionManager::new();
+    let subscription_manager = SubscriptionManager::new(Default::default());
     let (topic, subscription) =
         new_topic_and_subscription(&topic_manager, &subscription_manager).await;
 
@@ -123,38 +125,10 @@ async fn nack_messages() {
     assert_eq!(stats.backlog_messages_count, 0);
 }
 
-async fn new_topic_and_subscription(
-    topic_manager: &TopicManager,
-    subscription_manager: &SubscriptionManager,
-) -> (Arc<Topic>, Arc<Subscription>) {
-    let project_id = Uuid::new_v4().to_string();
-    let topic_id = Uuid::new_v4().to_string();
-    let sub_id = Uuid::new_v4().to_string();
-    let topic = topic_manager
-        .create_topic(TopicName::new(&project_id, &topic_id))
-        .unwrap();
-
-    let subscription = subscription_manager
-        .create_subscription(
-            SubscriptionInfo::new_with_defaults(SubscriptionName::new(&project_id, &sub_id)),
-            Arc::clone(&topic),
-        )
-        .await
-        .unwrap();
-
-    // Attach the subscription.
-    topic
-        .attach_subscription(Arc::clone(&subscription))
-        .await
-        .unwrap();
-
-    (topic, subscription)
-}
-
 #[tokio::test]
 async fn test_delete_subscription() {
     let topic_manager = TopicManager::new();
-    let subscription_manager = SubscriptionManager::new();
+    let subscription_manager = SubscriptionManager::new(Default::default());
     let (_, subscription) = new_topic_and_subscription(&topic_manager, &subscription_manager).await;
 
     // Subscribe to the notifiers, make sure it gets dropped.
@@ -178,6 +152,30 @@ async fn test_delete_subscription() {
     wait(joined).await;
 }
 
+#[tokio::test]
+async fn test_push_registry_integration() {
+    let topic_manager = TopicManager::new();
+    let push_registry = PushSubscriptionsRegistry::new();
+    let subscription_manager = SubscriptionManager::new(push_registry.clone());
+    let push_config = PushConfig::new("http://end.point".to_string(), None, None);
+    let (_, subscription) =
+        new_topic_and_subscription_fn(&topic_manager, &subscription_manager, |name| {
+            SubscriptionInfo::new(name, Duration::from_secs(10), Some(push_config.clone()))
+        })
+        .await;
+
+    // Make sure the registry was updated.
+    assert_eq!(push_registry.entries().len(), 1);
+    assert_eq!(push_registry.entries()[0].0, subscription.name);
+    assert_eq!(push_registry.entries()[0].1.endpoint, push_config.endpoint);
+
+    // Delete the subscription.
+    subscription.delete().await.unwrap();
+
+    // Make sure the entry was removed.
+    assert_eq!(push_registry.entries().len(), 0);
+}
+
 async fn wait(notified: impl std::future::Future<Output = ()>) {
     tokio::select! {
         _ = notified => {},
@@ -185,4 +183,43 @@ async fn wait(notified: impl std::future::Future<Output = ()>) {
             panic!("Timed out waiting for future")
         }
     }
+}
+
+async fn new_topic_and_subscription(
+    topic_manager: &TopicManager,
+    subscription_manager: &SubscriptionManager,
+) -> (Arc<Topic>, Arc<Subscription>) {
+    new_topic_and_subscription_fn(topic_manager, subscription_manager, |name| {
+        SubscriptionInfo::new_with_defaults(name)
+    })
+    .await
+}
+
+async fn new_topic_and_subscription_fn(
+    topic_manager: &TopicManager,
+    subscription_manager: &SubscriptionManager,
+    create_info: impl Fn(SubscriptionName) -> SubscriptionInfo,
+) -> (Arc<Topic>, Arc<Subscription>) {
+    let project_id = Uuid::new_v4().to_string();
+    let topic_id = Uuid::new_v4().to_string();
+    let sub_id = Uuid::new_v4().to_string();
+    let topic = topic_manager
+        .create_topic(TopicName::new(&project_id, &topic_id))
+        .unwrap();
+
+    let subscription = subscription_manager
+        .create_subscription(
+            create_info(SubscriptionName::new(&project_id, &sub_id)),
+            Arc::clone(&topic),
+        )
+        .await
+        .unwrap();
+
+    // Attach the subscription.
+    topic
+        .attach_subscription(Arc::clone(&subscription))
+        .await
+        .unwrap();
+
+    (topic, subscription)
 }

--- a/tests/topic_test.rs
+++ b/tests/topic_test.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 #[tokio::test]
 async fn delete_topic() {
     let topic_manager = TopicManager::new();
-    let subscription_manager = SubscriptionManager::new();
+    let push_registry = Default::default();
+    let subscription_manager = SubscriptionManager::new(push_registry);
 
     let topic_name = TopicName::new("test", "topic");
     let subscription_name = SubscriptionName::new("test", "subscription");


### PR DESCRIPTION
Add basic support for Push Subscriptions.

A single, global loop is used to pull messages from registered push subscriptions at a configurable interval, which are then dispatched to the registered push endpoint.